### PR TITLE
Spid hub dashboards

### DIFF
--- a/scripts/deploy/spidhub.yaml
+++ b/scripts/deploy/spidhub.yaml
@@ -447,3 +447,19 @@ Resources:
           - Orchestrator
           - Outputs.ListenerHttps
       TemplateURL: ./stacks/well-known.yaml
+
+  Dashboard:
+    Type: AWS::CloudFormation::Stack
+    DependsOn:
+    - HubLogin
+    - Cache
+    - Orchestrator
+    Properties:
+      Parameters:
+        Project: !Ref Project
+        Environment: !Ref Environment
+        RedisClusterName: !GetAtt Cache.Outputs.RedisClusterName
+        ApplicationLoadBalancer: !GetAtt Orchestrator.Outputs.ExternalALBFullName
+        HubLoginService: !GetAtt HubLogin.Outputs.ServiceName
+        HubLoginCluster: !GetAtt HubLogin.Outputs.ClusterName
+      TemplateURL: ./stacks/dashboard.yaml

--- a/scripts/deploy/stacks/cache.yaml
+++ b/scripts/deploy/stacks/cache.yaml
@@ -284,3 +284,7 @@ Outputs:
       Fn::GetAtt:
       - Redis
       - PrimaryEndPoint.Port
+
+  RedisClusterName:
+    Description: The redis cluster name
+    Value: !Sub ${Redis}

--- a/scripts/deploy/stacks/dashboard.yaml
+++ b/scripts/deploy/stacks/dashboard.yaml
@@ -1,0 +1,540 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: SPID Hub - Cloudwatch dashboard
+
+
+Parameters:
+  Project:
+    Description: The project
+    MinLength: 3
+    Type: String
+
+  Environment:
+    Description: The enviroment
+    MinLength: 3
+    Type: String
+    AllowedValues:
+    - dev
+    - uat
+    - prod
+    - svil
+    - coll
+    - cert
+    - hotfix
+
+  RedisClusterName:
+    Description: Redis cluster name
+    Type: String
+
+  ApplicationLoadBalancer:
+    Description: Application load balancer
+    Type: String
+
+  HubLoginService:
+    Description: Hub Login service name
+    Type: String
+
+  HubLoginCluster:
+    Description: Hub Login ECS cluster name
+    Type: String
+
+Resources:
+  # DashBoard
+  HubSpidLoginDashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: !Sub ${Project}-alarm-dashboard
+      DashboardBody: !Sub '{
+            "widgets": [
+                {
+                    "type": "alarm",
+                    "x": 0,
+                    "y": 0,
+                    "width": 24,
+                    "height": 2,
+                    "properties": {
+                        "alarms": [
+                          "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-EngineCPUUtilization",
+                          "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-CPUUtilization",
+                          "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-MemoryUsage",
+                          "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-CurrentConnections"
+                        ],
+                        "title": "Redis Alarms"
+                    }
+                },
+
+                {
+                    "type": "alarm",
+                    "x": 0,
+                    "y": 3,
+                    "width": 24,
+                    "height": 2,
+                    "properties": {
+                        "alarms": [
+                          "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-hub-ecs-cpu-utilization",
+                          "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-hub-ecs-memory-utilization",
+                          "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-hub-ecs-log-alarm"
+                        ],
+                        "title": "Hub login Alarms"
+                    }
+                },
+
+                {
+                    "type": "alarm",
+                    "x": 0,
+                    "y": 6,
+                    "width": 24,
+                    "height": 2,
+                    "properties": {
+                        "alarms": [
+                          "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-ExternalALBAlarm"
+                        ],
+                        "title": "Orchestrator Alarms"
+                    }
+                },
+
+                {
+                    "height": 1,
+                    "width": 24,
+                    "y": 12,
+                    "x": 0,
+                    "type": "text",
+                    "properties": {
+                        "markdown": "# Redis Alarms History" 
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 0,
+                    "y": 14,
+                    "width": 6,
+                    "height": 6,
+                    "properties": {
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "title": "Redis engine CPU utilization alarm history",
+                        "annotations": {
+                            "alarms": [
+                              "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-EngineCPUUtilization"
+                            ]
+                        },
+                        "liveData": false,
+                        "view": "timeSeries"
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 6,
+                    "y": 14,
+                    "width": 6,
+                    "height": 6,
+                    "properties": {
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "title": "Redis CPU utilization alarm history",
+                        "annotations": {
+                            "alarms": [
+                              "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-CPUUtilization"
+                            ]
+                        },
+                        "liveData": false,
+                        "view": "timeSeries"
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 12,
+                    "y": 14,
+                    "width": 6,
+                    "height": 6,
+                    "properties": {
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "title": "Redis memory usage alarm history",
+                        "annotations": {
+                            "alarms": [
+                              "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-MemoryUsage"
+                            ]
+                        },
+                        "liveData": false,
+                        "view": "timeSeries"
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 18,
+                    "y": 14,
+                    "width": 6,
+                    "height": 6,
+                    "properties": {
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "title": "Redis current connections alarm history",
+                        "annotations": {
+                            "alarms": [
+                              "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-CurrentConnections"   
+                            ]
+                        },
+                        "liveData": false,
+                        "view": "timeSeries"
+                    }
+                },
+
+                {
+                    "height": 1,
+                    "width": 24,
+                    "y": 21,
+                    "x": 0,
+                    "type": "text",
+                    "properties": {
+                        "markdown": "# Hub login alarms History" 
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 0,
+                    "y": 22,
+                    "width": 8,
+                    "height": 6,
+                    "properties": {
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "title": "Hub login ecs cpu utilization alarm history",
+                        "annotations": {
+                            "alarms": [
+                              "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-hub-ecs-cpu-utilization"
+                            ]
+                        },
+                        "liveData": false,
+                        "view": "timeSeries"
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 8,
+                    "y": 22,
+                    "width": 8,
+                    "height": 6,
+                    "properties": {
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "title": "Hub login ecs memory utilization alarm history",
+                        "annotations": {
+                            "alarms": [
+                              "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-hub-ecs-memory-utilization"
+                            ]
+                        },
+                        "liveData": false,
+                        "view": "timeSeries"
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 16,
+                    "y": 22,
+                    "width": 8,
+                    "height": 6,
+                    "properties": {
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "title": "Hub login log alarm history",
+                        "annotations": {
+                            "alarms": [
+                              "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-hub-ecs-log-alarm"
+                            ]
+                        },
+                        "liveData": false,
+                        "view": "timeSeries"
+                    }
+                },
+
+                {
+                    "height": 1,
+                    "width": 24,
+                    "y": 38,
+                    "x": 0,
+                    "type": "text",
+                    "properties": {
+                        "markdown": "# Orchestrator alarms History" 
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 0,
+                    "y": 40,
+                    "width": 24,
+                    "height": 6,
+                    "properties": {
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "title": "Orchestrator ALB alarm",
+                        "annotations": {
+                            "alarms": [
+                              "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-ExternalALBAlarm"
+                            ]
+                        },
+                        "liveData": false,
+                        "view": "timeSeries"
+                    }
+                }
+            ]
+        }'
+
+  # DashBoard
+  HubSpidLoginServiceDashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: !Sub ${Project}-service-dashboard
+      DashboardBody: !Sub '{
+            "widgets": [
+                {
+                    "height": 1,
+                    "width": 24,
+                    "y": 0,
+                    "x": 0,
+                    "type": "text",
+                    "properties": {
+                        "markdown": "# Redis metrics" 
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 0,
+                    "y": 2,
+                    "width": 12,
+                    "height": 6,
+                    "properties": {
+                        "metrics": [
+                          [ "AWS/ElastiCache", "CurrConnections", "CacheClusterId", "${RedisClusterName}-001" ],
+                          [ "AWS/ElastiCache", "CurrConnections", "CacheClusterId", "${RedisClusterName}-002" ]
+                        ],
+                        "title": "Redis current connections",
+                        "view": "timeSeries",
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "stat": "Sum",
+                        "period": 300
+                    }
+                },
+                {
+                    "type": "metric",
+                    "x": 12,
+                    "y": 2,
+                    "width": 12,
+                    "height": 6,
+                    "properties": {
+                        "metrics": [
+                          [ "AWS/ElastiCache", "Evictions", "CacheClusterId", "${RedisClusterName}-001" ],
+                          [ "AWS/ElastiCache", "Evictions", "CacheClusterId", "${RedisClusterName}-002" ]
+                        ],
+                        "title": "Redis evictions",
+                        "view": "timeSeries",
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "stat": "Sum",
+                        "period": 300
+                    }
+                },
+                {
+                    "type": "metric",
+                    "x": 0,
+                    "y": 11,
+                    "width": 8,
+                    "height": 6,
+                    "properties": {
+                        "metrics": [
+                          [ "AWS/ElastiCache", "CurrItems", "CacheClusterId", "${RedisClusterName}-001" ],
+                          [ "AWS/ElastiCache", "CurrItems", "CacheClusterId", "${RedisClusterName}-002" ]
+                        ],
+                        "title": "Redis current items",
+                        "view": "timeSeries",
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "stat": "Sum",
+                        "period": 300
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 8,
+                    "y": 11,
+                    "width": 8,
+                    "height": 6,
+                    "properties": {
+                        "metrics": [
+                          [ "AWS/ElastiCache", "CacheHits", "CacheClusterId", "${RedisClusterName}-001" ],
+                          [ "AWS/ElastiCache", "CacheHits", "CacheClusterId", "${RedisClusterName}-002" ]
+                        ],
+                        "title": "Redis cache hits",
+                        "view": "timeSeries",
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "stat": "Sum",
+                        "period": 300
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 16,
+                    "y": 11,
+                    "width": 8,
+                    "height": 6,
+                    "properties": {
+                        "metrics": [
+                          [ "AWS/ElastiCache", "CacheMisses", "CacheClusterId", "${RedisClusterName}-001" ] ,
+                          [ "AWS/ElastiCache", "CacheMisses", "CacheClusterId", "${RedisClusterName}-002" ]
+                        ],
+                        "title": "Redis cache misses",
+                        "view": "timeSeries",
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "stat": "Sum",
+                        "period": 300
+                    }
+                },
+                {
+                    "height": 1,
+                    "width": 24,
+                    "y": 18,
+                    "x": 0,
+                    "type": "text",
+                    "properties": {
+                        "markdown": "# External Application Load Balancer metrics" 
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 0,
+                    "y": 20,
+                    "width": 6,
+                    "height": 6,
+                    "properties": {
+                        "metrics": [
+                          [ "AWS/ApplicationELB", "ConsumedLCUs", "LoadBalancer", "${ApplicationLoadBalancer}"]
+                        ],
+                        "title": "ALB consumed CLUs",
+                        "view": "timeSeries",
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "stat": "Sum",
+                        "period": 300
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 6,
+                    "y": 20,
+                    "width": 6,
+                    "height": 6,
+                    "properties": {
+                        "metrics": [
+                          [ "AWS/ApplicationELB", "RequestCount", "LoadBalancer", "${ApplicationLoadBalancer}"]
+                        ],
+                        "title": "ALB request count",
+                        "view": "timeSeries",
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "stat": "Sum",
+                        "period": 300
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 12,
+                    "y": 20,
+                    "width": 6,
+                    "height": 6,
+                    "properties": {
+                        "metrics": [
+                          [ "AWS/ApplicationELB", "HTTPCode_ELB_5XX_Count", "LoadBalancer", "${ApplicationLoadBalancer}"]
+                        ],
+                        "title": "ALB 5xx",
+                        "view": "timeSeries",
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "stat": "Sum",
+                        "period": 300
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 18,
+                    "y": 20,
+                    "width": 6,
+                    "height": 6,
+                    "properties": {
+                        "metrics": [
+                          [ "AWS/ApplicationELB", "HTTPCode_ELB_4XX_Count", "LoadBalancer", "${ApplicationLoadBalancer}"]
+                        ],
+                        "title": "ALB 4xx",
+                        "view": "timeSeries",
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "stat": "Sum",
+                        "period": 300
+                    }
+                },
+
+                {
+                    "height": 1,
+                    "width": 24,
+                    "y": 27,
+                    "x": 0,
+                    "type": "text",
+                    "properties": {
+                        "markdown": "# Hub Login ECS metrics" 
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 0,
+                    "y": 29,
+                    "width": 12,
+                    "height": 6,
+                    "properties": {
+                        "metrics": [
+                          [ "AWS/ECS", "CPUUtilization", "ServiceName", "${HubLoginService}", "ClusterName", "${HubLoginCluster}" ]
+                        ],
+                        "title": "Hub Login ECS CPU Utilization",
+                        "view": "timeSeries",
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "stat": "Average",
+                        "period": 300
+                    }
+                },
+                {
+                    "type": "metric",
+                    "x": 12,
+                    "y": 29,
+                    "width": 12,
+                    "height": 6,
+                    "properties": {
+                        "metrics": [
+                          [ "AWS/ECS", "MemoryUtilization", "ServiceName", "${HubLoginService}", "ClusterName", "${HubLoginCluster}" ]
+                        ],
+                        "title": "Hub Login ECS Memory Utilization",
+                        "view": "timeSeries",
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "stat": "Average",
+                        "period": 300
+                    }
+                }
+            ]
+        }'

--- a/scripts/deploy/stacks/hub-login.yaml
+++ b/scripts/deploy/stacks/hub-login.yaml
@@ -602,8 +602,50 @@ Resources:
       Threshold: !Ref MemoryUtilizationThreshold
       TreatMissingData: missing
 
+  # CloudWatch metric to filer ERROR lines, in Log group
+  ErrorLogsMetricFilter: 
+    Condition: AlarmEnabled
+    Type: AWS::Logs::MetricFilter
+    Properties: 
+      LogGroupName: !Ref LogGroup
+      FilterPattern: '?Error ?error'
+      MetricTransformations: 
+        - MetricValue: 1
+          MetricNamespace: "ErrorLogs"
+          MetricName: "HubLogin-ErrorMetric"
+  
+  # Create alarm
+  ErrorLogsMetricAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmEnabled
+    DependsOn: ErrorLogsMetricFilter
+    Properties:
+      AlarmName: !Sub ${Project}-${Environment}-hub-ecs-log-alarm
+      AlarmDescription: "CloudWatch alarm for when ECS LogGroup has ERROR line."
+      TreatMissingData: notBreaching
+      AlarmActions: 
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}"
+      OKActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}"
+      DatapointsToAlarm: 1
+      MetricName: "HubLogin-ErrorMetric"
+      Namespace: "ErrorLogs"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 60
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+
 Outputs:
   SamlAssertionLogBucket:
     Description: The ARN of the SAML Assertion Bucket
     Value:
       Ref: SamlAssertionLogBucket
+
+  ServiceName:
+    Description: Saml check service name
+    Value: !GetAtt Service.Name
+  
+  ClusterName:
+    Description: ECS Cluster Name
+    Value: !Ref Cluster

--- a/scripts/deploy/stacks/orchestrator.yaml
+++ b/scripts/deploy/stacks/orchestrator.yaml
@@ -363,56 +363,6 @@ Resources:
         Fn::Sub: "*.${DomainName}"
       Type: A
 
-  ECSCPUUtilizationAlarm:
-    Condition: AlarmEnabled
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: !Sub ${Project}-${Environment}-orchestrator-ecs-cpu-utilization
-      AlarmDescription: "CloudWatch alarm for spid hub Orchestrator ECS CPU Utilization."
-      AlarmActions: 
-        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
-      InsufficientDataActions:
-        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
-      OKActions:
-        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
-      DatapointsToAlarm: 1
-      Dimensions: 
-        - Name: ClusterName
-          Value: !Ref Cluster
-      MetricName: CPUUtilization
-      Namespace: AWS/ECS
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: 60
-      Period: 60
-      Statistic: Sum
-      Threshold: !Ref CPUUtilizationThreshold
-      TreatMissingData: missing
-
-  ECSMemoryUtilizationAlarm:
-    Condition: AlarmEnabled
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: !Sub ${Project}-${Environment}-orchestrator-ecs-memory-utilization
-      AlarmDescription: "CloudWatch alarm for spid hub Orchestrator ECS Memory Utilization."
-      AlarmActions: 
-        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
-      InsufficientDataActions:
-        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
-      OKActions:
-        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
-      DatapointsToAlarm: 1
-      Dimensions: 
-        - Name: ClusterName
-          Value: !Ref Cluster
-      MetricName: MemoryUtilization
-      Namespace: AWS/ECS
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: 60
-      Period: 60
-      Statistic: Sum
-      Threshold: !Ref MemoryUtilizationThreshold
-      TreatMissingData: missing
-
   ApplicationLoadBalancerAlarm:
     Condition: AlarmEnabled
     Type: AWS::CloudWatch::Alarm
@@ -483,6 +433,10 @@ Outputs:
     Description: SecurityGroup of the ALB
     Value:
       Ref: InternalAlbSecurityGroup
+
+  ExternalALBFullName:
+    Description: External ALB full name
+    Value: !GetAtt ExternalApplicationLoadBalancer.LoadBalancerFullName
 
   ListenerHttps:
     Description: HTTPS Listerner for ALB

--- a/scripts/deploy/stacks/spid-saml-check.yaml
+++ b/scripts/deploy/stacks/spid-saml-check.yaml
@@ -464,3 +464,182 @@ Resources:
       Statistic: Sum
       Threshold: !Ref MemoryUtilizationThreshold
       TreatMissingData: missing
+
+  # CloudWatch metric to filer ERROR -  lines, in Log group
+  ErrorLogsMetricFilter: 
+    Condition: AlarmEnabled
+    Type: AWS::Logs::MetricFilter
+    Properties: 
+      LogGroupName: !Ref LogGroup
+      FilterPattern: '?Error ?error'
+      MetricTransformations: 
+        - MetricValue: 1
+          MetricNamespace: "ErrorLogs"
+          MetricName: "SamlCheck-ErrorMetric"
+  
+  # Create alarm
+  ErrorLogsMetricAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmEnabled
+    DependsOn: ErrorLogsMetricFilter
+    Properties:
+      AlarmName: !Sub ${Project}-${Environment}-saml-check-alarm
+      AlarmDescription: "CloudWatch alarm for when ECS LogGroup has ERROR line."
+      TreatMissingData: notBreaching
+      AlarmActions: 
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}"
+      OKActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}"
+      DatapointsToAlarm: 1
+      MetricName: "SamlCheck-ErrorMetric"
+      Namespace: "ErrorLogs"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 60
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+
+  # DashBoard
+  SamlCheckServiceDashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: !Sub ${Project}-saml-check-dashboard
+      DashboardBody: !Sub '{
+            "widgets": [
+              {
+                    "type": "alarm",
+                    "x": 0,
+                    "y": 9,
+                    "width": 24,
+                    "height": 2,
+                    "properties": {
+                        "alarms": [
+                          "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-spid-ecs-cpu-utilization",
+                          "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-spid-ecs-memory-utilization",
+                          "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-saml-check-alarm"
+                        ],
+                        "title": "Saml check Alarms"
+                    }
+                },
+
+                {               
+                    "height": 1,
+                    "width": 24,
+                    "y": 29,
+                    "x": 0,
+                    "type": "text",
+                    "properties": {
+                        "markdown": "# Saml check alarm History" 
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 0,
+                    "y": 31,
+                    "width": 8,
+                    "height": 6,
+                    "properties": {
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "title": "Saml check ecs cpu utilization alarm history",
+                        "annotations": {
+                            "alarms": [
+                              "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-spid-ecs-cpu-utilization"
+                            ]
+                        },
+                        "liveData": false,
+                        "view": "timeSeries"
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 8,
+                    "y": 31,
+                    "width": 8,
+                    "height": 6,
+                    "properties": {
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "title": "Saml check ecs memory utilization alarm history",
+                        "annotations": {
+                            "alarms": [
+                          "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-spid-ecs-memory-utilization"
+                            ]
+                        },
+                        "liveData": false,
+                        "view": "timeSeries"
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 16,
+                    "y": 31,
+                    "width": 8,
+                    "height": 6,
+                    "properties": {
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "title": "Saml check log alarm",
+                        "annotations": {
+                            "alarms": [
+                              "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-saml-check-alarm"
+                            ]
+                        },
+                        "liveData": false,
+                        "view": "timeSeries"
+                    }
+                },
+
+
+                {
+                    "height": 1,
+                    "width": 24,
+                    "y": 34,
+                    "x": 0,
+                    "type": "text",
+                    "properties": {
+                        "markdown": "# Saml check ECS metrics" 
+                    }
+                },
+
+                {
+                    "type": "metric",
+                    "x": 0,
+                    "y": 35,
+                    "width": 12,
+                    "height": 6,
+                    "properties": {
+                        "metrics": [
+                          [ "AWS/ECS", "CPUUtilization", "ServiceName", "${Service.Name}", "ClusterName", "${Cluster}"]
+                        ],
+                        "title": "Saml Check ECS Memory Utilization",
+                        "view": "timeSeries",
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "stat": "Average",
+                        "period": 300
+                    }
+                },
+                {
+                    "type": "metric",
+                    "x": 12,
+                    "y": 34,
+                    "width": 12,
+                    "height": 6,
+                    "properties": {
+                        "metrics": [
+                          [ "AWS/ECS", "MemoryUtilization", "ServiceName", "${Service.Name}", "ClusterName", "${Cluster}"]
+                        ],
+                        "title": "Saml Check ECS Memory Utilization",
+                        "view": "timeSeries",
+                        "stacked": false,
+                        "region": "${AWS::Region}",
+                        "stat": "Average",
+                        "period": 300
+                    }
+                }
+            ]
+        }'


### PR DESCRIPTION
- Created 3 dashboards: 
   - saml-check (optional, created only in NON PROD env)
   - service
   - alarm

Removed two orchestrator alarms that weren't correctly aggregated by dimensions.