### PR TITLE
Disabled error log alarm

### DIFF
--- a/scripts/deploy/stacks/dashboard.yaml
+++ b/scripts/deploy/stacks/dashboard.yaml
@@ -72,8 +72,7 @@ Resources:
                     "properties": {
                         "alarms": [
                           "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-hub-ecs-cpu-utilization",
-                          "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-hub-ecs-memory-utilization",
-                          "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-hub-ecs-log-alarm"
+                          "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-hub-ecs-memory-utilization"
                         ],
                         "title": "Hub login Alarms"
                     }
@@ -199,7 +198,7 @@ Resources:
                     "type": "metric",
                     "x": 0,
                     "y": 22,
-                    "width": 8,
+                    "width": 12,
                     "height": 6,
                     "properties": {
                         "stacked": false,
@@ -219,7 +218,7 @@ Resources:
                     "type": "metric",
                     "x": 8,
                     "y": 22,
-                    "width": 8,
+                    "width": 12,
                     "height": 6,
                     "properties": {
                         "stacked": false,
@@ -228,26 +227,6 @@ Resources:
                         "annotations": {
                             "alarms": [
                               "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-hub-ecs-memory-utilization"
-                            ]
-                        },
-                        "liveData": false,
-                        "view": "timeSeries"
-                    }
-                },
-
-                {
-                    "type": "metric",
-                    "x": 16,
-                    "y": 22,
-                    "width": 8,
-                    "height": 6,
-                    "properties": {
-                        "stacked": false,
-                        "region": "${AWS::Region}",
-                        "title": "Hub login log alarm history",
-                        "annotations": {
-                            "alarms": [
-                              "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${Project}-${Environment}-hub-ecs-log-alarm"
                             ]
                         },
                         "liveData": false,

--- a/scripts/deploy/stacks/hub-login.yaml
+++ b/scripts/deploy/stacks/hub-login.yaml
@@ -648,27 +648,29 @@ Resources:
           MetricNamespace: "ErrorLogs"
           MetricName: "HubLogin-ErrorMetric"
   
+  # NOTE: The error log alarm has been disabled due to a bug on hub-spid-login-ms that logs an error on each successfull login (HSL-17). 
+  # Login service can still be monitored using spidhub-<codice-ambiente>-ExternalALBAlarm Alarm.
   # Create alarm
-  ErrorLogsMetricAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: AlarmEnabled
-    DependsOn: ErrorLogsMetricFilter
-    Properties:
-      AlarmName: !Sub ${Project}-${Environment}-hub-ecs-log-alarm
-      AlarmDescription: "CloudWatch alarm for when ECS LogGroup has ERROR line."
-      TreatMissingData: notBreaching
-      AlarmActions: 
-        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}"
-      OKActions:
-        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}"
-      DatapointsToAlarm: 1
-      MetricName: "HubLogin-ErrorMetric"
-      Namespace: "ErrorLogs"
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: 60
-      Period: 60
-      Statistic: Sum
-      Threshold: 1
+  # ErrorLogsMetricAlarm:
+  #   Type: AWS::CloudWatch::Alarm
+  #   Condition: AlarmEnabled
+  #   DependsOn: ErrorLogsMetricFilter
+  #   Properties:
+  #     AlarmName: !Sub ${Project}-${Environment}-hub-ecs-log-alarm
+  #     AlarmDescription: "CloudWatch alarm for when ECS LogGroup has ERROR line."
+  #     TreatMissingData: notBreaching
+  #     AlarmActions: 
+  #       - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}"
+  #     OKActions:
+  #       - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}"
+  #     DatapointsToAlarm: 1
+  #     MetricName: "HubLogin-ErrorMetric"
+  #     Namespace: "ErrorLogs"
+  #     ComparisonOperator: GreaterThanOrEqualToThreshold
+  #     EvaluationPeriods: 60
+  #     Period: 60
+  #     Statistic: Sum
+  #     Threshold: 1
 
   # Bucket Policy to allow readonly bucket access from Helpdesk account ECS Role
   SamlAssertionHelpdeskResourcePolicy:


### PR DESCRIPTION
The modification disables error log alarms because spid-hub-login-ms currently logs an error on each successfull login.